### PR TITLE
Instead of formatting changes, fail the test if code needs formatting

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,13 +2,9 @@ name: Format
 
 on:
   push:
-    branches:
-      - main
     paths:
       - 'utils/**'
   pull_request:
-    branches:
-      - main
     paths:
       - 'utils/**'
 
@@ -30,18 +26,10 @@ jobs:
         run: |
           pip install ruff isort
 
-      - name: Run Ruff formatter
+      - name: Run Ruff check
         run: |
-          ruff format utils/
+          ruff check utils/
 
-      - name: Run isort
+      - name: Run isort check
         run: |
-          isort utils/
-
-      - name: Commit and push changes
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add utils/
-          git commit -m "Auto-format: Applied ruff format and isort" || exit 0
-          git push
+          isort --check-only utils/


### PR DESCRIPTION
There were some bugs with the autoformatter, so instead now the user have to manually format their code before committing their changes.

If not, the github action will fail.