### PR TITLE
Additional configuration files and options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,5 @@ jobs:
 
     - name: Run tests
       run: |
-        PYTHONPATH=. pytest .
+        pytest
       shell: bash -el {0}

--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+.envrc

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+addopts = -ra -q


### PR DESCRIPTION
Add a few simple configuration options:
- Add `.direnv` to .gitignore such that it is possible to modify local path. This wont affect anyone, but if you are interested in having a `./bin` directory and having scripts inside added to your path, such that you can run the script `bin/sync-springfield` only using the command `sync-springfield` then check out [direnv](https://direnv.net/)
- Add a pytest configuration file. This makes it a lot easier to run pytest commands. Now you only need to call `pytest`, and all options are already specified in `pytest.ini`.
- Added a commit for testing if the above works for our github action.