### PR TITLE
Fix bug where usps test weren't able to download usps data

### DIFF
--- a/CollaborativeCoding/dataloaders/download.py
+++ b/CollaborativeCoding/dataloaders/download.py
@@ -130,7 +130,7 @@ class Downloader:
         url_test, _, test_md5 = USPS_SOURCE["test"]
 
         # Using temporary directory ensures temporary files are deleted after use
-        with TemporaryDirectory() as tmp_dir:
+        with TemporaryDirectory(dir=data_dir) as tmp_dir:
             train_path = Path(tmp_dir) / "train"
             test_path = Path(tmp_dir) / "test"
 

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -25,10 +25,13 @@ from CollaborativeCoding.load_data import load_data
     ],
 )
 def test_load_data(data_name, expected):
+    data_dir = Path("Data")
+    data_dir.mkdir(exist_ok=True)
+
     dataset, _, _ = load_data(
         data_name,
         train=False,
-        data_dir=Path("Data"),
+        data_dir=data_dir,
         transform=transforms.ToTensor(),
     )
 


### PR DESCRIPTION
I noticed a bug where if `Data/usps.h5` did not already exist, `tests/test_dataloader.py` were for some reason not able to download the data correctly.

I suspect this could be due to `TemporaryDirectory` not being able to write to the `/tmp` directory in the container, so this draft PR is to see if adding `TemporaryDirectory(dir="Data") fixes this as the container has write permissions here anyways... 🤞🏻 