### PR TITLE
Fixed a small bug in metric wrapper

### DIFF
--- a/CollaborativeCoding/load_metric.py
+++ b/CollaborativeCoding/load_metric.py
@@ -79,6 +79,7 @@ class MetricWrapper(nn.Module):
                 raise ValueError(f"Metric {key} not supported")
 
     def __call__(self, y_true, y_pred):
+        y_true, y_pred = y_true.detach().cpu(), y_pred.detach().cpu()
         for key in self.metrics:
             self.metrics[key](y_true, y_pred)
 

--- a/CollaborativeCoding/metrics/EntropyPred.py
+++ b/CollaborativeCoding/metrics/EntropyPred.py
@@ -36,7 +36,6 @@ class EntropyPrediction(nn.Module):
         assert y_logits.size(-1) == self.num_classes, (
             f"y_logit class length: {y_logits.size(-1)}, expected: {self.num_classes}"
         )
-
         y_pred = nn.Softmax(dim=1)(y_logits)
         print(f"y_pred: {y_pred}")
         entropy_values = entropy(y_pred, axis=1)

--- a/CollaborativeCoding/metrics/EntropyPred.py
+++ b/CollaborativeCoding/metrics/EntropyPred.py
@@ -37,14 +37,12 @@ class EntropyPrediction(nn.Module):
             f"y_logit class length: {y_logits.size(-1)}, expected: {self.num_classes}"
         )
         y_pred = nn.Softmax(dim=1)(y_logits)
-        print(f"y_pred: {y_pred}")
         entropy_values = entropy(y_pred, axis=1)
         entropy_values = th.from_numpy(entropy_values)
 
         # Fix numerical errors for perfect guesses
         entropy_values[entropy_values == th.inf] = 0
         entropy_values = th.nan_to_num(entropy_values)
-        print(f"Entropy Values: {entropy_values}")
         for sample in entropy_values:
             self.stored_entropy_values.append(sample.item())
 


### PR DESCRIPTION
Found that some metrics might not have made sure all metrics are on the same device. Made the MetricWrapper force `y_true` and `y_logits` onto the cpu