### PR TITLE
Fixing __reset__ method for precision

### DIFF
--- a/CollaborativeCoding/metrics/precision.py
+++ b/CollaborativeCoding/metrics/precision.py
@@ -121,7 +121,8 @@ class Precision(nn.Module):
         None
             Returns None
         """
-        self.y_true = self.y_pred = []
+        self.y_true = []
+        self.y_pred = []
         return None
 
 


### PR DESCRIPTION
When used in the precision did not reset itself correctly, resulting in precision = 1 forall epochs > 1. @Johanmkr