### PR TITLE
Update build-image.yml

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,7 +3,13 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `main`.
 on:
   push:
-    branches: ['main']
+    paths:
+      - "pyproject.toml"
+      - "Dockerfile"
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "Dockerfile"
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:


### PR DESCRIPTION
Since this job takes so long to run, only run it when `pyproject.toml` or `Dockerfile` is modified, which is its only real dependencies.

This is pretty much the same this happening as in #108, but update in separate commit due to diverging branches.