### PR TITLE
Restrict python version < 3.13 and update version

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,6 +17,6 @@ authors:
   given-names: "Johan"
   orcid: "https://orcid.org/0009-0005-8580-372X"
 title: "Collaborative Coding Exam"
-version: 1.0.0
+version: 1.1.0
 date-released: 2025-02-26
 url: "https://github.com/SFI-Visual-Intelligence/Collaborative-Coding-Exam"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "collaborative-coding-exam"
-version = "0.1.0"
+version = "1.1.0"
 description = "Exam project in the collaborative coding course."
 readme = "README.md"
-requires-python = ">=3.11.5"
+requires-python = ">=3.11.5, <3.13"
 dependencies = [
     "black>=25.1.0",
     "h5py>=3.12.1",


### PR DESCRIPTION
This pull request is meant to restrict the python version in the docker image to < 3.13. Closes #122.

I also updated the version to v1.1.0, and tried to push a new tag, we'll see if that works 👍🏻 